### PR TITLE
Error when defined trusted accounts parameter closes #33

### DIFF
--- a/perimeter/shared_access.sp
+++ b/perimeter/shared_access.sp
@@ -510,7 +510,7 @@ control "ec2_ami_shared_with_trusted_accounts" {
         public,
         string_agg(lp ->> 'Group', ',') as public_access,
         to_jsonb(string_to_array(string_agg(lp ->> 'UserId', ','), ',')) as shared_accounts,
-        to_jsonb(string_to_array(string_agg(lp ->> 'UserId', ','), ',')) - ($1)::text as untrusted_accounts,
+        to_jsonb(string_to_array(string_agg(lp ->> 'UserId', ','), ',')) - ($1)::text[] as untrusted_accounts,
         region,
         _ctx,
         tags,
@@ -519,7 +519,7 @@ control "ec2_ami_shared_with_trusted_accounts" {
         all_amis,
         jsonb_array_elements(launch_permissions) lp
       group by
-        title, 
+        title,
         public,
         region,
         _ctx,


### PR DESCRIPTION
```
steampipe check control.ec2_ami_shared_with_trusted_accounts

+ EC2 AMIs should only be shared with trusted accounts .............................................................................................................................. 0 / 1 [==========]
  | 
  OK   : hashistack-21111111111634 is not shared. ............................................................................................................................... us-east-2 531111111111
```